### PR TITLE
tweak setup.py to work on OS X

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -179,7 +179,7 @@ if CYTHON_AVAILABLE:
 	# Path: {CYTHON_DIR}/Includes/libcpp/sfml.pxd
 	cython_headers = []
 
-	if platform.system() == 'Linux':
+	if platform.system() in ['Linux', 'Darwin']:
 		pxd_files = glob('include/libcpp/*')
 		pxd_files.remove('include/libcpp/http')
 		pxd_files.remove('include/libcpp/ftp')


### PR DESCRIPTION
Right now there are two cases for building the pxd list: Linux, and non-Linux. The non-Linux case assumes windows style paths.

This minor tweak let me build on OS X.
