### PR TITLE
Fix string representations of Transform class

### DIFF
--- a/src/sfml/graphics.pyx
+++ b/src/sfml/graphics.pyx
@@ -344,11 +344,15 @@ cdef class Transform:
 
 	def __repr__(self):
 		cdef float *p = <float*>self.p_this.getMatrix()
-		return "Transform({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8})".format(p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8])
+		return "Transform({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8})".format(
+                    p[0], p[4], p[12], p[1], p[5], p[13], p[3], p[7], p[15])
 
 	def __str__(self):
 		cdef float *p = <float*>self.p_this.getMatrix()
-		return "[{0}, {1}, {2}]\n[{3}, {4}, {5}]\n[{6}, {7}, {8}]".format(str(p[0])[:3], str(p[1])[:3], str(p[2])[:3], str(p[3])[:3], str(p[7])[:3], str(p[5])[:3], str(p[6])[:3], str(p[7])[:3], str(p[8])[:3])
+		return "[{0}, {1}, {2}]\n[{3}, {4}, {5}]\n[{6}, {7}, {8}]".format(
+                    str(p[0])[:3], str(p[4])[:3], str(p[12])[:3],
+                    str(p[1])[:3], str(p[5])[:3], str(p[13])[:3],
+                    str(p[3])[:3], str(p[7])[:3], str(p[15])[:3])
 
 	def __mul__(Transform x, Transform y):
 		r = Transform()

--- a/tests/graphics/test_transform.py
+++ b/tests/graphics/test_transform.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# pySFML - Python bindings for SFML
+# Copyright 2012-2013, Edwin Marshall <emarshall85@gmail.com>
+#
+# This software is released under the LGPLv3 license.
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+import pytest
+from sfml import Transform
+
+def test_transform_repr():
+    t = Transform().translate((2, 3))
+    assert repr(t) == 'Transform(1.0, 0.0, 2.0, 0.0, 1.0, 3.0, 0.0, 0.0, 1.0)'
+    t = Transform.from_values(1, 2, 3, 4, 5, 6, 7, 8, 9)
+    assert repr(t) == 'Transform(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0)'
+
+def test_transform_str():
+    t = Transform.from_values(1, 2, 3, 4, 5, 6, 7, 8, 9)
+    assert str(t) == '[1.0, 2.0, 3.0]\n[4.0, 5.0, 6.0]\n[7.0, 8.0, 9.0]'


### PR DESCRIPTION
I stumbled upon this inconsistency in the Transform class' string representations, while doing some debugging output.

From the commit message:

The underlying C-array of floats is a 4x4 matrix, of which only a 3x3 subcomponent is relevant in the context of 2D transformations. The access of its indices have been fixed accordingly. There was also a mix-up of col-major and row-major order.

This fix makes the string representations consistent with the signature of the from_values constructor. Tests ensuring this behaviour have been added.
