### PR TITLE
Fix invalid link on README.rst at line 28

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ obtained by issuing the following additional commands::
 Alternatively, you may clone the main project and its submodules all at once
 with the following command::
 
-    git clone --recursive git://github.com:Sonkun/python-sfml.git
+    git clone --recursive git://github.com/Sonkun/python-sfml.git
     cd python-sfml
 
 Resources


### PR DESCRIPTION
The recursive cloning link was of type git://, but with ssh like path separator
resulting in an unusable command line.
