### PR TITLE
Update gettingstarted.rst

### DIFF
--- a/doc/source/gettingstarted.rst
+++ b/doc/source/gettingstarted.rst
@@ -186,6 +186,6 @@ inside.
    vector2.y = 1.16
 
    vector3 = sf.Vector3()
-   vector3.x = Decimal(0.333333333)
+   vector3.x = float(0.333333333)
 
    x, y, z = vector3 # you can unpack the vector


### PR DESCRIPTION
Python doesn't have a Decimal type, assuming float.

Also this example causes a traceback, I'm not sure if this is intentional to show off that the window size cannot be changed or not:

```
Type "help", "copyright", "credits" or "license" for more information.
>>> import sfml as sf
>>> w = sf.RenderWindow(sf.VideoMode(640, 480), "My first pySFML Window - or not ?")
>>> w.clear(sf.Color.BLUE)
>>> w.display()
>>> w.size = (800, 600)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: attribute 'size' of 'sfml.graphics.RenderWindow' objects is not writable
```