### PR TITLE
Remove redundant String class definition

### DIFF
--- a/include/libcpp/sfml.pxd
+++ b/include/libcpp/sfml.pxd
@@ -134,7 +134,6 @@ cdef extern from "SFML/System.hpp" namespace "sf":
 
     cdef cppclass InputStream
     cdef cppclass Utf
-    cdef cppclass String
 
 cimport style, event, videomode, keyboard, joystick, mouse, touch, sensor
 


### PR DESCRIPTION
This commit intend to fix issue #106

Cython >= 0.21 handle class redefinitions diffrently than prior versions.
This redundant declaration cause an "AnalyseDeclarationsTransform" exception.

This commit removes the redundant declaration in order to fix that (btw, I don't think that the redeclaration is required).