### PR TITLE
Build fixes (#118 and #119)

### DIFF
--- a/include/Includes/sfml/style.pxd
+++ b/include/Includes/sfml/style.pxd
@@ -23,7 +23,7 @@
 #-------------------------------------------------------------------------------
 
 cdef extern from "SFML/Window.hpp" namespace "sf::Style":
-    cdef enum Style:
+    cdef enum:
         None
         Titlebar
         Resize

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ else:
 
 system = extension(
     'system',
-    [sources['system'], 'src/sfml/error.cpp', 'src/sfml/NumericObject.cpp', 'src/sfml/hacks.cpp'],
+    [sources['system'], 'src/sfml/error.cpp', 'src/sfml/NumericObject.cpp'],
     ['sfml-system'])
 
 window = extension(


### PR DESCRIPTION
These are the fixes I've used to get python-sfml building again on my machine. I'll probably apply the one relating to Cython 0.23 to the Debian package in a moment.