### PR TITLE
pip install --user fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,12 +129,9 @@ c_api_headers.append(os.path.join(include_path, 'graphics.h'))
 c_api_headers.append(os.path.join(include_path, 'graphics_api.h'))
 c_api_headers.append(os.path.join(include_path, 'audio_api.h'))
 
-if platform.system() == 'Windows':
-    # On Windows: C:\Python27\include\pysfml\*_api.h
-    files = [('include\\pysfml', c_api_headers)]
-else:
-    # On Unix: /usr/local/include/pysfml/*_api.h
-    files = [('include/pysfml', c_api_headers)]
+# On Windows: C:\Python27\include\pysfml\*_api.h
+# On Unix: /usr/local/include/pysfml/*_api.h
+files = [(os.path.join('include', 'pysfml'), c_api_headers)]
 
 if platform.system() == 'Windows':
     dlls = [("Lib\\site-packages\\sfml", glob('extlibs/sfml/bin/' + arch + '/*.dll'))]

--- a/setup.py
+++ b/setup.py
@@ -131,10 +131,10 @@ c_api_headers.append(os.path.join(include_path, 'audio_api.h'))
 
 if platform.system() == 'Windows':
     # On Windows: C:\Python27\include\pysfml\*_api.h
-    files = [(sys.exec_prefix +'\\include\\pysfml', c_api_headers)]
+    files = [('include\\pysfml', c_api_headers)]
 else:
     # On Unix: /usr/local/include/pysfml/*_api.h
-    files = [(sys.exec_prefix + '/include/pysfml', c_api_headers)]
+    files = [('include/pysfml', c_api_headers)]
 
 if platform.system() == 'Windows':
     dlls = [("Lib\\site-packages\\sfml", glob('extlibs/sfml/bin/' + arch + '/*.dll'))]


### PR DESCRIPTION
Fixes `pip install --user` failing with "permission denied" error.

What failed before: `pip install --user` copies all Python files correctly to `~/.local/lib/python3.5/site-packages/`, but then tries to copy C headers to absolute path pointed by `sys.exec_prefix` - which still points to system-global directory when installing with `--user`.

The fix: use relative paths, `setup()` will take care of them properly.

For reference: https://docs.python.org/3/distutils/setupscript.html#installing-additional-files
> Each (directory, files) pair in the sequence specifies the installation directory and the files to install there. If directory is a relative path, it is interpreted relative to the installation prefix (Python’s sys.prefix for pure-Python packages, sys.exec_prefix for packages that contain extension modules).

Also, I needed to manually apply patches from #120 to make it build at all, but for the purpose of PR, I rebased them to master.