### PR TITLE
Fix documentation build failure with sphinx 1.4

### DIFF
--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -67,6 +67,7 @@ Voip
 Embedding
 ---------
 .. literalinclude:: /../../examples/embedding/main.cpp
+   :language: c++
    :linenos:
 
 .. literalinclude:: /../../examples/embedding/script.py
@@ -75,6 +76,7 @@ Embedding
 Extending
 ---------
 .. literalinclude:: /../../examples/extending/extension.pyx
+   :language: cython
    :linenos:
 
 .. literalinclude:: /../../examples/extending/main.py

--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -82,8 +82,3 @@ Extending
 .. literalinclude:: /../../examples/extending/main.py
    :linenos:
 
-Spacial Music
--------------
-.. literalinclude:: /../../examples/spacial_music/spacial_music.py
-   :linenos:
-


### PR DESCRIPTION
Sphinx 1.4 added a new warning which is emitted if it fails to syntax highlight a block of code. This warning causes the documentation to fail to build with this error because the code cannot be parsed as python:

```
Warning, treated as error:
/<builddir>/doc/source/examples.rst:69:
WARNING: Could not lex literal_block as "python". Highlighting skipped.
```

This PR sets the correct syntax highlighting language so the code can be parsed and the warning isn't emitted.

I also removed the reference to the spacial music example which was recently deleted.
