### PR TITLE
Added __int__() function to Color in graphics.pyx. Fixes #155: "Color…

### DIFF
--- a/src/sfml/graphics/graphics.pyx
+++ b/src/sfml/graphics/graphics.pyx
@@ -209,6 +209,9 @@ cdef public class Color [type PyColorType, object PyColorObject]:
     def __str__(self):
         return "(R={0}, G={1}, B={2}, A={3})".format(self.r, self.g, self.b, self.a)
 
+    def __int__(self):
+        return (((self.r & 0xFF) << 24) | ((self.g & 0xFF) << 16) | ((self.b & 0xFF) << 8) | (self.a & 0xFF))
+
     def __iter__(self):
         return iter((self.r, self.g, self.b, self.a))
 


### PR DESCRIPTION
__int__(self): added to the Color class in graphics.pyx, just like in sfml; https://www.sfml-dev.org/documentation/2.4.2/classsf_1_1Color.php#a48f75a30fc93e79390e6d700e4b4b558
https://github.com/SFML/SFML/blob/fae3b65f0567f87fa9925cd42d28df15eb69e79c/src/SFML/Graphics/Color.cpp

What SFML does:
1. shifts red (which is a uint8) 24 bits to the left
2. shifts green (which is a uint8) 16 bits to the left
3. shifts blue (which is a uint8) 8 bits to the left
4. ORs (|) red, green, blue, and alpha together, forming a uint32 representation of the rgba color.

What this does:
Same, but since this is python it ANDs (&) self.r/g/b/a with 0xFF (8 bits) to make sure the shifting doesn't end up bigger or smaller than a 32bit uint.

```
SFML example: (1 << 24) | (2 << 16) | (3 << 8) | 4;
returns: 16909060

python-sfml: sf.Color(1,2,3,4).__int__()
returns: 16909060 
```
